### PR TITLE
No messages can be added by customer if ticket is resolved or closed

### DIFF
--- a/client/src/AddMessageForm.jsx
+++ b/client/src/AddMessageForm.jsx
@@ -6,8 +6,9 @@ const AddMessageForm = ({ userEmail, caseId, onMessageAdded, isSessionActive = t
 
     const handleSubmit = (e) => {
         e.preventDefault();
+        // Ange en alert om sessionen inte är aktiv (dvs ticketstatus=Closed/Resolved)
         if (!isSessionActive) {
-            alert("Sessionen är avslutad. Du kan inte lägga till fler meddelanden.");
+            alert("Ticket is closed. You cannot add new messages.");
             return;
         }
 
@@ -17,7 +18,7 @@ const AddMessageForm = ({ userEmail, caseId, onMessageAdded, isSessionActive = t
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify({ email: userEmail, content: messageContent }),
-            credentials: 'include',
+            credentials: 'include'
         })
         .then(response => {
             if (!response.ok) {
@@ -29,9 +30,11 @@ const AddMessageForm = ({ userEmail, caseId, onMessageAdded, isSessionActive = t
         })
         .then(() => {
             setMessageContent("");
-            onMessageAdded(); // Uppdatera meddelandelistan efter att ett meddelande lagts till
+            onMessageAdded(); // Uppdatera meddelandelistan
         })
         .catch(error => {
+            // Visa en alert med felmeddelandet
+            alert(error.message);
             console.error('Error adding message:', error);
         });
     };
@@ -43,10 +46,9 @@ const AddMessageForm = ({ userEmail, caseId, onMessageAdded, isSessionActive = t
                 onChange={(e) => setMessageContent(e.target.value)}
                 placeholder="Enter your message"
                 required
-                disabled={!isSessionActive}
             />
             <div className="button-container">
-                <button type="submit" className="add-message-button" disabled={!isSessionActive}>
+                <button type="submit" className="add-message-button">
                     Add Message
                 </button>
             </div>

--- a/client/src/Customer/CustomerCases/CustomerCases.css
+++ b/client/src/Customer/CustomerCases/CustomerCases.css
@@ -1,10 +1,10 @@
-/* Container för hela chat session-sidan */
+/* Container for the chat session page */
 .cases-container {
     display: flex;
     flex-direction: column;
     margin: 20px;
     margin-left: 240px;
-    /* Tar hänsyn till sidpanelens bredd */
+    /* Consider sidebar width */
     padding: 20px;
     background-color: #f5f5f5;
     border-radius: 8px;
@@ -21,13 +21,12 @@
     }
 }
 
-/* Rubrik */
 h2 {
     font-family: Arial, Helvetica, sans-serif;
     margin-bottom: 20px;
 }
 
-/* Ärendedetaljer */
+/* Ticket details styling */
 .case-details {
     margin-top: 20px;
     padding: 10px;
@@ -36,7 +35,7 @@ h2 {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-/* Meddelandelistan */
+/* Message list styling */
 .messages-list {
     list-style: none;
     padding: 0;
@@ -45,7 +44,7 @@ h2 {
     flex-direction: column;
 }
 
-/* Gemensam stil för meddelanden */
+/* Common message item styling */
 .message-item {
     padding: 10px;
     margin-bottom: 10px;
@@ -55,21 +54,21 @@ h2 {
     word-wrap: break-word;
 }
 
-/* Kundmeddelanden: grön bakgrund, vänsterjusterade */
+/* Styling for customer messages (green background, left aligned) */
 .customer-message {
     background-color: #c2e7bf;
     color: #155724;
     align-self: flex-start;
 }
 
-/* Supportmeddelanden: blå bakgrund, högerjusterade */
+/* Styling for support messages (blue background, right aligned) */
 .support-message {
     background-color: #a5cad1;
     color: #0c5460;
     align-self: flex-end;
 }
 
-/* Styling för nedräkningstimer */
+/* Styling for the session timer */
 .session-timer {
     font-size: 14px;
     font-family: Arial, Helvetica, sans-serif;
@@ -77,7 +76,7 @@ h2 {
     color: #333;
 }
 
-/* Styling för formuläret att lägga till meddelande */
+/* Styling for the "Add a Message" form */
 .add-message-form {
     display: flex;
     flex-direction: column;
@@ -96,13 +95,13 @@ h2 {
     resize: vertical;
 }
 
-/* Container för knappar i formuläret */
+/* Container for the form buttons */
 .button-container {
     display: flex;
     gap: 10px;
 }
 
-/* Stil för knappen "Add Message" */
+/* Styling for the "Add Message" button */
 .add-message-button {
     background-color: #75B9BE;
     border: none;

--- a/server/Database/DatabaseDump/dissatisfiedcustomer-dump.sql
+++ b/server/Database/DatabaseDump/dissatisfiedcustomer-dump.sql
@@ -2,13 +2,12 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 17.2
--- Dumped by pg_dump version 17.2
+-- Dumped from database version 16.4
+-- Dumped by pg_dump version 16.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
-SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -345,6 +344,24 @@ CREATE VIEW public.tickets_pending AS
 
 
 ALTER VIEW public.tickets_pending OWNER TO postgres;
+
+--
+-- Name: tickets_with_status; Type: VIEW; Schema: public; Owner: postgres
+--
+
+CREATE VIEW public.tickets_with_status AS
+ SELECT t.id,
+    t.date,
+    t.title,
+    t.user_email AS email,
+    t.case_number,
+    t.description,
+    ts.status_name
+   FROM (public.tickets t
+     LEFT JOIN public.ticketstatus ts ON ((t.status_id = ts.id)));
+
+
+ALTER VIEW public.tickets_with_status OWNER TO postgres;
 
 --
 -- Name: ticketstatus_column_name_seq; Type: SEQUENCE; Schema: public; Owner: postgres
@@ -706,7 +723,7 @@ SELECT pg_catalog.setval('public.employees_id_seq', 15, true);
 -- Name: messages_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.messages_id_seq', 22, true);
+SELECT pg_catalog.setval('public.messages_id_seq', 26, true);
 
 
 --
@@ -720,7 +737,7 @@ SELECT pg_catalog.setval('public.product_id_seq', 15, true);
 -- Name: tickets_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.tickets_id_seq', 21, true);
+SELECT pg_catalog.setval('public.tickets_id_seq', 23, true);
 
 
 --

--- a/server/Routes/CaseRoutes.cs
+++ b/server/Routes/CaseRoutes.cs
@@ -1,98 +1,67 @@
 using Npgsql;
 using Microsoft.AspNetCore.Http.HttpResults;
 using server;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace server;
-
-public static class CaseRoutes
+namespace server
 {
-   /*  Avnänds inte på nåt sätt i projektet för att 
-   
-   
-   // Hämtar ärenden baserat på kundens e-post
-    public static async Task<List<CaseDetails>> GetUserCasesByEmail(string userEmail, NpgsqlDataSource db)
+    public static class CaseRoutes
     {
-        var result = new List<CaseDetails>();
-        using var cmd = db.CreateCommand("SELECT t.id, t.title, t.description, t.case_number, ts.status_name, t.date " +
-                                          "FROM tickets t JOIN ticketstatus ts ON t.status_id = ts.id " +
-                                          "WHERE t.user_email = $1");
-        cmd.Parameters.AddWithValue(userEmail);
-
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        // Adds a message for a ticket based on the customer's email.
+        // UPDATED: Now includes a validation step to check the ticket status before inserting a new message.
+        // If the ticket’s status_id is 3 (Resolved) or 4 (Closed), we return a BadRequest.
+        public static async Task<Results<Ok, NotFound, BadRequest<string>>> AddCaseMessageByEmail(string userEmail, int caseId, Message message, NpgsqlDataSource db)
         {
-            result.Add(new CaseDetails(
-                reader.GetInt32(0),
-                reader.GetString(1),
-                reader.GetString(2),
-                reader.IsDBNull(3) ? "N/A" : reader.GetString(3),
-                reader.GetString(4),
-                reader.GetDateTime(5)
-            ));
+            // First check that the ticket exists for the given email.
+            using var checkCmd = db.CreateCommand("SELECT COUNT(*) FROM tickets WHERE id = $1 AND user_email = $2");
+            checkCmd.Parameters.AddWithValue(caseId);
+            checkCmd.Parameters.AddWithValue(userEmail);
+            var caseExists = (long)await checkCmd.ExecuteScalarAsync() > 0;
+            if (!caseExists)
+            {
+                return TypedResults.NotFound();
+            }
+
+            // NEW: Check the current status of the ticket.
+            await using var statusCmd = db.CreateCommand("SELECT status_id FROM tickets WHERE id = $1");
+            statusCmd.Parameters.AddWithValue(caseId);
+            var statusResult = await statusCmd.ExecuteScalarAsync();
+            int statusId = Convert.ToInt32(statusResult);
+            // In our schema: 3 = Resolved, 4 = Closed.
+            if (statusId == 3 || statusId == 4)
+            {
+                return TypedResults.BadRequest("Cannot add message to closed or resolved ticket.");
+            }
+
+            // If ticket is active, proceed with inserting the message.
+            using var cmd = db.CreateCommand("INSERT INTO messages (ticket_id, message, email) VALUES ($1, $2, $3)");
+            cmd.Parameters.AddWithValue(caseId);
+            cmd.Parameters.AddWithValue(message.Content);
+            cmd.Parameters.AddWithValue(userEmail);
+            await cmd.ExecuteNonQueryAsync();
+
+            return TypedResults.Ok();
         }
-        return result;
-    }
 
-    // Hämtar detaljer för ett specifikt ärende baserat på kundens e-post och caseId
-    public static async Task<Results<Ok<CaseDetails>, NotFound>> GetCaseDetailsByEmail(string userEmail, int caseId, NpgsqlDataSource db)
-    {
-        using var cmd = db.CreateCommand("SELECT t.id, t.title, t.description, t.case_number, ts.status_name, t.date " +
-                                          "FROM tickets t JOIN ticketstatus ts ON t.status_id = ts.id " +
-                                          "WHERE t.user_email = $1 AND t.id = $2");
-        cmd.Parameters.AddWithValue(userEmail);
-        cmd.Parameters.AddWithValue(caseId);
-
-        using var reader = await cmd.ExecuteReaderAsync();
-        if (!await reader.ReadAsync())
+        // Retrieves messages for a ticket based on the customer's email.
+        public static async Task<List<MessageDetails>> GetCaseMessagesByEmail(string userEmail, int caseId, NpgsqlDataSource db)
         {
-            return TypedResults.NotFound();
+            var result = new List<MessageDetails>();
+            using var cmd = db.CreateCommand("SELECT id, email, message FROM messages WHERE ticket_id = $1 AND email = $2");
+            cmd.Parameters.AddWithValue(caseId);
+            cmd.Parameters.AddWithValue(userEmail);
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                result.Add(new MessageDetails(
+                    reader.GetInt32(0),
+                    reader.GetString(1),  // Ensure the email is read as a string.
+                    reader.GetString(2)
+                ));
+            }
+            return result;
         }
-        var caseDetails = new CaseDetails(
-            reader.GetInt32(0),
-            reader.GetString(1),
-            reader.GetString(2),
-            reader.IsDBNull(3) ? "N/A" : reader.GetString(3),
-            reader.GetString(4),
-            reader.GetDateTime(5)
-        );
-        return TypedResults.Ok(caseDetails);
-    } */
-
-    // Lägger till ett meddelande för ett ärende via kundens e-post
-    public static async Task<Results<Ok, NotFound>> AddCaseMessageByEmail(string userEmail, int caseId, Message message, NpgsqlDataSource db)
-    {
-        using var checkCmd = db.CreateCommand("SELECT COUNT(*) FROM tickets WHERE id = $1 AND user_email = $2");
-        checkCmd.Parameters.AddWithValue(caseId);
-        checkCmd.Parameters.AddWithValue(userEmail);
-        var caseExists = (long)await checkCmd.ExecuteScalarAsync() > 0;
-        if (!caseExists)
-        {
-            return TypedResults.NotFound();
-        }
-        using var cmd = db.CreateCommand("INSERT INTO messages (ticket_id, message, email) VALUES ($1, $2, $3)");
-        cmd.Parameters.AddWithValue(caseId);
-        cmd.Parameters.AddWithValue(message.Content);
-        cmd.Parameters.AddWithValue(userEmail);
-        await cmd.ExecuteNonQueryAsync();
-        return TypedResults.Ok();
-    }
-
-    // Hämtar meddelanden för ett ärende via kundens e-post
-    public static async Task<List<MessageDetails>> GetCaseMessagesByEmail(string userEmail, int caseId, NpgsqlDataSource db)
-    {
-        var result = new List<MessageDetails>();
-        using var cmd = db.CreateCommand("SELECT id, email, message FROM messages WHERE ticket_id = $1 AND email = $2");
-        cmd.Parameters.AddWithValue(caseId);
-        cmd.Parameters.AddWithValue(userEmail);
-        using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
-        {
-            result.Add(new MessageDetails(
-                reader.GetInt32(0),
-                reader.GetString(1),  // Ändrat från GetInt32 till GetString
-                reader.GetString(2)
-            ));
-        }
-        return result;
     }
 }

--- a/server/Routes/MessageRoutes.cs
+++ b/server/Routes/MessageRoutes.cs
@@ -4,166 +4,194 @@ using MailKit.Net.Smtp;
 using MimeKit;
 using MailKit.Security;
 using System;
-using System.Data.Common;
 
-namespace server;
-
-public static class MessageRoutes
+namespace server
 {
-    // Dataöverföringsobjekt för inkommande meddelanden från kund.
-    // Kunden fyller i sin e-post, men får inget konto – vi använder e-posten direkt.
-    
-
-    // Metod för att hantera POST /api/messages för kundens meddelande.
-    // UPPDATERAD: Vi tar inte längre emot/skapar user_id, utan använder Email och genererar en token för kundsession
-    public static async Task<Results<Created, BadRequest<string>>> PostMessage(MessageDTO message, HttpContext context, NpgsqlDataSource db)
+    public static class MessageRoutes
     {
-        Console.WriteLine($"Received Message - Email: {message.Email}, Name: {message.Name}, Content: {message.Content}, CompanyID: {message.CompanyID}");
+        // Data Transfer Object (DTO) for incoming customer messages.
+        // Customers provide their email, and we use that directly (no user account is created).
+       
 
-        // Validera inkommande data.
-        if (string.IsNullOrEmpty(message.Email) || string.IsNullOrEmpty(message.Name) || string.IsNullOrEmpty(message.Content))
+        // Method to handle POST /api/messages for a customer message.
+        // UPDATED: We no longer receive/create a user_id; instead, we use Email and generate a token for the customer session.
+        public static async Task<Results<Created, BadRequest<string>>> PostMessage(MessageDTO message, HttpContext context, NpgsqlDataSource db)
         {
-            return TypedResults.BadRequest("Email, Name, and Content are required.");
+            Console.WriteLine($"Received Message - Email: {message.Email}, Name: {message.Name}, Content: {message.Content}, CompanyID: {message.CompanyID}");
+
+            // Validate required data.
+            if (string.IsNullOrEmpty(message.Email) || string.IsNullOrEmpty(message.Name) || string.IsNullOrEmpty(message.Content))
+                return TypedResults.BadRequest("Email, Name, and Content are required.");
+
+            using var conn = db.CreateConnection();
+            await conn.OpenAsync();
+
+            // Start a transaction to ensure data integrity.
+            await using var transaction = await conn.BeginTransactionAsync();
+
+            try
+            {
+                // I PostMessage-metoden, efter att vi har skapat ticketen:
+                int ticketId = await CreateTicketForCustomerAsync(message.Email, message.Name, message.Content, message.CompanyID, conn, transaction);
+
+                // Hämtar nu aktuell status (status_id) — enligt er databasschema: 
+                // status_id 3 = Resolved, status_id 4 = Closed.
+                int currentStatus = await GetTicketStatus(ticketId, conn, transaction);
+                if (currentStatus == 3 || currentStatus == 4)
+                {
+                    // Om status är Resolved eller Closed, returneras ett fel.
+                    return TypedResults.BadRequest("Cannot add message to closed or resolved ticket.");
+                }
+
+
+                // Insert the customer’s message into the database.
+                await using var cmd = conn.CreateCommand();
+                cmd.Transaction = transaction;
+                cmd.CommandText = "INSERT INTO messages (ticket_id, message, email) VALUES ($1, $2, $3)";
+                cmd.Parameters.AddWithValue(ticketId);
+                cmd.Parameters.AddWithValue(message.Content);
+                cmd.Parameters.AddWithValue(message.Email);
+                await cmd.ExecuteNonQueryAsync();
+                Console.WriteLine("Message inserted successfully!");
+
+                // Commit the transaction.
+                await transaction.CommitAsync();
+
+                // Retrieve the generated token (recorded as case_number) from the ticket.
+                string token = GetTicketToken(ticketId, conn, transaction);
+
+                // Create a session by storing the token.
+                context.Session.SetString("UserSession", token);
+                Console.WriteLine($"Session created with token: {token}");
+
+                // Send a confirmation email to the customer using MailKit with Gmail SMTP.
+                await SendConfirmationEmailAsync(message.Email, message.Name, message.Content, token);
+
+                return TypedResults.Created();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Exception: {ex.Message}");
+                Console.WriteLine($"Stack Trace: {ex.StackTrace}");
+                if (transaction != null && transaction.Connection != null)
+                {
+                    try { await transaction.RollbackAsync(); }
+                    catch (Exception rollbackEx)
+                    {
+                        Console.WriteLine($"Rollback Exception: {rollbackEx.Message}");
+                        Console.WriteLine($"Rollback Stack Trace: {rollbackEx.StackTrace}");
+                    }
+                }
+                return TypedResults.BadRequest($"An error occurred: {ex.Message}");
+            }
+            finally
+            {
+                if (conn.State == System.Data.ConnectionState.Open)
+                    await conn.CloseAsync();
+            }
         }
 
-        using var conn = db.CreateConnection();
-        await conn.OpenAsync();
-
-        // Starta en transaktion för att säkerställa dataintegritet.
-        await using var transaction = await conn.BeginTransactionAsync();
-
-        try
+        // Creates a new ticket (case) for the customer.
+        // UPDATED: Uses email instead of user_id and generates a token stored in case_number.
+        private static async Task<int> CreateTicketForCustomerAsync(string email, string title, string description, int company_id, NpgsqlConnection conn, NpgsqlTransaction transaction)
         {
-            int ticketId = await CreateTicketForCustomerAsync(message.Email, message.Name, message.Content, message.CompanyID, conn, transaction);
-
             await using var cmd = conn.CreateCommand();
             cmd.Transaction = transaction;
-            cmd.CommandText = "INSERT INTO messages (ticket_id, message, email) VALUES ($1, $2, $3)";
+            // Generate a unique token using GenerateUniqueCaseNumber() and use it as the case_number.
+            string token = GenerateUniqueCaseNumber();
+            cmd.CommandText = "INSERT INTO tickets (user_email, title, description, case_number, company_id, date, status_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id";
+            cmd.Parameters.AddWithValue(email);
+            cmd.Parameters.AddWithValue(title);
+            cmd.Parameters.AddWithValue(description);
+            cmd.Parameters.AddWithValue(token);   // Save token as case_number.
+            cmd.Parameters.AddWithValue(company_id);
+            cmd.Parameters.AddWithValue(DateTime.UtcNow);
+            cmd.Parameters.AddWithValue(1);         // Default status_id is 1 (Unread)
+
+            var scalar = await cmd.ExecuteScalarAsync();
+            if (scalar == null)
+                throw new InvalidOperationException("Failed to create ticket; returned ID is null.");
+
+            int ticketId = (int)scalar;
+            Console.WriteLine($"Ticket created with token (case_number): {token}");
+            return ticketId;
+        }
+
+        // Retrieves the token (case_number) for a given ticketId.
+        private static string GetTicketToken(int ticketId, NpgsqlConnection conn, NpgsqlTransaction transaction)
+        {
+            using var cmd = conn.CreateCommand();
+            cmd.Transaction = transaction;
+            cmd.CommandText = "SELECT case_number FROM tickets WHERE id = $1";
             cmd.Parameters.AddWithValue(ticketId);
-            cmd.Parameters.AddWithValue(message.Content);
-            cmd.Parameters.AddWithValue(message.Email);
-
-            await cmd.ExecuteNonQueryAsync();
-            Console.WriteLine("Message inserted successfully!");
-
-            await transaction.CommitAsync();
-
-            // Hämta det genererade tokenet från ärendet (lagrat i case_number).
-            string token = GetTicketToken(ticketId, conn, transaction);
-
-            // Skapa en session och sätt token som sessionsvärde.
-            context.Session.SetString("UserSession", token);
-            Console.WriteLine($"Session created with token: {token}");
-
-            await SendConfirmationEmailAsync(message.Email, message.Name, message.Content, token);
-
-            return TypedResults.Created();
+            var result = cmd.ExecuteScalar();
+            return result?.ToString() ?? "";
         }
-        catch (Exception ex)
+
+        // Retrieves the status of a ticket given its ticketId.
+        // This method ensures that no new messages can be added if the status is "Closed" or "Resolved".
+        // Ny metod för att hämta ticketstatus (status_id) baserat på ticketId.
+        private static async Task<int> GetTicketStatus(int ticketId, NpgsqlConnection conn, NpgsqlTransaction transaction)
         {
-            Console.WriteLine($"Exception: {ex.Message}");
-            Console.WriteLine($"Stack Trace: {ex.StackTrace}");
-            if (transaction != null && transaction.Connection != null)
+            await using var cmd = conn.CreateCommand();
+            cmd.Transaction = transaction;
+            cmd.CommandText = "SELECT status_id FROM tickets WHERE id = $1";
+            cmd.Parameters.AddWithValue(ticketId);
+            var result = await cmd.ExecuteScalarAsync();
+            if (result == null)
             {
-                try
-                {
-                    await transaction.RollbackAsync();
-                }
-                catch (Exception rollbackEx)
-                {
-                    Console.WriteLine($"Rollback Exception: {rollbackEx.Message}");
-                    Console.WriteLine($"Rollback Stack Trace: {rollbackEx.StackTrace}");
-                }
+                throw new InvalidOperationException("No status found for ticket.");
             }
-            return TypedResults.BadRequest($"An error occurred: {ex.Message}");
+            return Convert.ToInt32(result);
         }
-        finally
+
+
+        // Generates a random password. (Exposed for external use.)
+        public static string GenerateRandomPassword()
         {
-            if (conn.State == System.Data.ConnectionState.Open)
+            return Guid.NewGuid().ToString().Substring(0, 8);
+        }
+
+        // Generates a unique token/case number.
+        private static string GenerateUniqueCaseNumber()
+        {
+            return $"CASE-{Guid.NewGuid().ToString().Substring(0, 8).ToUpper()}";
+        }
+
+        // Sends a confirmation email using MailKit with Gmail SMTP.
+        // UPDATED: Uses baseUrl set to the frontend (http://localhost:5173).
+        private static async Task SendConfirmationEmailAsync(string email, string name, string content, string token)
+        {
+            string baseUrl = "http://localhost:5173"; // Frontend base URL
+
+            string messageBody = $"Dear {name ?? "Customer"},\n\nWe have received your message:\n\n\"{content}\"\n\n" +
+                                 $"To access your chat with customer support, please click the link below within the next hour:\n" +
+                                 $"{baseUrl}/tickets/view/{token}\n\n" +
+                                 $"Thank you for contacting us.\n\nBest regards,\nYour App Team";
+
+            var mimeMessage = new MimeMessage();
+            mimeMessage.From.Add(new MailboxAddress("Your App Name", "dissatisfiedcustomer2025@gmail.com"));
+            mimeMessage.To.Add(new MailboxAddress(name ?? "Customer", email));
+            mimeMessage.Subject = "Chat Access Confirmation";
+            mimeMessage.Body = new TextPart("plain") { Text = messageBody };
+
+            try
             {
-                await conn.CloseAsync();
+                using var smtpClient = new SmtpClient();
+                // For testing purposes, disable certificate validation.
+                smtpClient.ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+                smtpClient.Connect("smtp.gmail.com", 587, SecureSocketOptions.StartTls);
+                smtpClient.Authenticate("dissatisfiedcustomer2025@gmail.com", "yxel egbr xehm wdrt");
+                await smtpClient.SendAsync(mimeMessage);
+                await smtpClient.DisconnectAsync(true);
+                Console.WriteLine("Confirmation email sent successfully!");
             }
-        }
-    }
-
-    // Skapar ett nytt ärende (ticket) för kund.
-    // UPPDATERAD: Använder email istället för user_id, och genererar ett token (sparat i case_number).
-    private static async Task<int> CreateTicketForCustomerAsync(string email, string title, string description, int company_id, NpgsqlConnection conn, NpgsqlTransaction transaction)
-    {
-        await using var cmd = conn.CreateCommand();
-        cmd.Transaction = transaction;
-        // Generera ett unikt token via GenerateUniqueCaseNumber och använd det även som case_number.
-        string token = GenerateUniqueCaseNumber();
-        cmd.CommandText = "INSERT INTO tickets (user_email, title, description, case_number, company_id, date, status_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id";
-        cmd.Parameters.AddWithValue(email);
-        cmd.Parameters.AddWithValue(title);
-        cmd.Parameters.AddWithValue(description);
-        cmd.Parameters.AddWithValue(token); // Sparar token som case_number.
-        cmd.Parameters.AddWithValue(company_id);
-        cmd.Parameters.AddWithValue(DateTime.UtcNow);
-        cmd.Parameters.AddWithValue(1); // Sätter default status_id till 1 (Unread)
-
-        var ticketId = (int)(await cmd.ExecuteScalarAsync() ?? throw new InvalidOperationException("Failed to create ticket."));
-        Console.WriteLine($"Ticket created with token (case_number): {token}");
-        return ticketId;
-    }
-
-    // Hjälpfunktion: Hämta token (case_number) för ett givet ticketId.
-    private static string GetTicketToken(int ticketId, NpgsqlConnection conn, NpgsqlTransaction transaction)
-    {
-        using var cmd = conn.CreateCommand();
-        cmd.Transaction = transaction;
-        cmd.CommandText = "SELECT case_number FROM tickets WHERE id = $1";
-        cmd.Parameters.AddWithValue(ticketId);
-        var result = cmd.ExecuteScalar();
-        return result?.ToString() ?? "";
-    }
-
-    // Genererar ett slumpmässigt lösenord (används inte direkt för kund, men finns för andra syften).
-    public static string GenerateRandomPassword()
-    {
-        return Guid.NewGuid().ToString().Substring(0, 8);
-    }
-
-    // Genererar ett unikt token / ärendenummer.
-    private static string GenerateUniqueCaseNumber()
-    {
-        return $"CASE-{Guid.NewGuid().ToString().Substring(0, 8).ToUpper()}";
-    }
-
-    // Skickar bekräftelsemail med MailKit via Googles SMTP-server.
-    // UPPDATERAD: Använder Gmail SMTP med baseUrl satt till din frontend (http://localhost:5173)
-    private static async Task SendConfirmationEmailAsync(string email, string name, string content, string token)
-    {
-        string baseUrl = "http://localhost:5173"; // Uppdaterad bas-URL
-
-        string messageBody = $"Dear {name ?? "Customer"},\n\nWe have received your message:\n\n\"{content}\"\n\n" +
-                             $"To access your chat with customer support, please click the link below within the next hour:\n" +
-                             $"{baseUrl}/tickets/view/{token}\n\n" +
-                             $"Thank you for contacting us.\n\nBest regards,\nYour App Team";
-
-        var mimeMessage = new MimeMessage();
-        mimeMessage.From.Add(new MailboxAddress("Your App Name", "dissatisfiedcustomer2025@gmail.com"));
-        mimeMessage.To.Add(new MailboxAddress(name ?? "Customer", email));
-        mimeMessage.Subject = "Chat Access Confirmation";
-        mimeMessage.Body = new TextPart("plain") { Text = messageBody };
-
-        try
-        {
-            using var smtpClient = new SmtpClient();
-            // För testning: inaktivera certifikatvalidering
-            smtpClient.ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
-            smtpClient.Connect("smtp.gmail.com", 587, SecureSocketOptions.StartTls);
-            smtpClient.Authenticate("dissatisfiedcustomer2025@gmail.com", "yxel egbr xehm wdrt");
-            await smtpClient.SendAsync(mimeMessage);
-            await smtpClient.DisconnectAsync(true);
-            Console.WriteLine("Confirmation email sent successfully!");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Email sending failed: {ex.Message}");
-            Console.WriteLine($"Email sending Stack Trace: {ex.StackTrace}");
-            throw;
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Email sending failed: {ex.Message}");
+                Console.WriteLine($"Email sending Stack Trace: {ex.StackTrace}");
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
Customers are no longer allowed to add new messages if the ticket’s status is "Resolved" or "Closed".
If a customer attempts to submit a message in such a state, an alert is displayed informing them that the ticket is closed.

The database dump has been updated to include a view that returns all necessary fields, including status_name